### PR TITLE
Return scene vector s_1:n and event vector e_1:n

### DIFF
--- a/src/run_engine.py
+++ b/src/run_engine.py
@@ -1,5 +1,6 @@
 #import sys  # not used
-from engine import *  # this import makes it really hard to understand the code
+import argparse
+from engine import main
 
 # get input arguments
 parser = argparse.ArgumentParser()
@@ -19,48 +20,6 @@ n_repeats = args.get('n_consecutive_repeats')[0]
 n_input_files = len(input_fnames)
 names_concat = '_'.join(input_fnames)
 
-
-# sample stories from schema
-# Returns a scene (state) vector s_1:n formatted for HRR encoding
-# as well as a sequence of event labels e_1:n according to the story type
-#
-def main(rand_seed, stories_kwargs=None):
-    if stories_kwargs is None:
-        stories_kwargs = dict(
-            mark_end_state=False,  # attach end_of_state, end_of_story marker
-            attach_questions=False,  # attach question marker at the end of the state (e.g. Q_subject)
-            gen_symbolic_states=False,  # GEN_SYMBOLIC_STATES = False
-            attach_role_marker=False,  # ATTACH_ROLE_MARKER = False
-            attach_role_maker_before=['Pronoun', 'Name', 'Pronoun_possessive', 'Pronoun_object'],
-        )
-
-    # get a handle on the output file
-    output_path = mkdir(names_concat, n_iterations, n_repeats)
-    f_stories = open_output_file(output_path, names_concat, n_iterations, n_repeats)
-    f_QA = open_output_file(output_path, names_concat + '_QA', n_iterations, n_repeats)
-    # read all schema files
-    schema_info = []
-    for i in range(n_input_files):
-        schema_info.append(read_schema_file(input_fnames[i]))
-
-    scenes = [] # s_1:n
-    events = [] # e_1:n
-    # write stories with alternating schema info
-    for i in range(n_input_files * n_iterations):
-        f_idx = np.mod(i, n_input_files)
-        # write to the output file
-        rand_seed, schema_scenes = write_stories(schema_info[f_idx],
-                                  f_stories, f_QA,
-                                  rand_seed, n_repeats, **stories_kwargs)
-        scenes.extend(schema_scenes)
-        events.extend([f_idx] * len(schema_scenes))
-    assert len(events) == len(scenes)
-
-    f_stories.close()
-    f_QA.close()
-
-    return scenes, events
-
 if __name__ == "__main__":
     # set the constants for the stories
     stories_kwargs = dict(
@@ -75,4 +34,5 @@ if __name__ == "__main__":
     if n_input_files == 1:
         n_iterations = n_iterations * n_repeats
         n_repeats = 1
-    main(0, stories_kwargs)
+
+    main(0, input_fnames, n_input_files, names_concat, n_iterations, n_repeats, write_to_files=True, stories_kwargs=stories_kwargs)

--- a/src/run_engine.py
+++ b/src/run_engine.py
@@ -21,6 +21,9 @@ names_concat = '_'.join(input_fnames)
 
 
 # sample stories from schema
+# Returns a scene (state) vector s_1:n formatted for HRR encoding
+# as well as a sequence of event labels e_1:n according to the story type
+#
 def main(rand_seed, stories_kwargs=None):
     if stories_kwargs is None:
         stories_kwargs = dict(
@@ -40,16 +43,23 @@ def main(rand_seed, stories_kwargs=None):
     for i in range(n_input_files):
         schema_info.append(read_schema_file(input_fnames[i]))
 
+    scenes = [] # s_1:n
+    events = [] # e_1:n
     # write stories with alternating schema info
     for i in range(n_input_files * n_iterations):
         f_idx = np.mod(i, n_input_files)
         # write to the output file
-        rand_seed = write_stories(schema_info[f_idx],
+        rand_seed, schema_scenes = write_stories(schema_info[f_idx],
                                   f_stories, f_QA,
                                   rand_seed, n_repeats, **stories_kwargs)
+        scenes.extend(schema_scenes)
+        events.extend([f_idx] * len(schema_scenes))
+    assert len(events) == len(scenes)
 
     f_stories.close()
     f_QA.close()
+
+    return scenes, events
 
 if __name__ == "__main__":
     # set the constants for the stories


### PR DESCRIPTION
Return scene vector s_1:n and event vector e_1:n
in a format that's convenient for HRR encoding and passing to SEM.

Apologies that I'm using the world "scene" instead of "state". I'm
trying to stick with this nomenclature as "state" is an ambiguous term
that can stand for many other things in the model.

Also fixed a couple of small bugs:
- cond_fill is not always unicode and for me it was erroring out with
AttributeError: 'str' object has no attribute 'isnumeric'
- when GEN_SYMBOLIC_STATES and ATTACH_ROLE_MARKER are both set, the
role-filler pairs were printed multiple times (e.g. in the Dessert_crumble scene). I added
the vector used_fillers to keep track of the fillers independent of the
roles.